### PR TITLE
Fix for rain rate and barometer readings

### DIFF
--- a/bin/user/ambientweatherapi.py
+++ b/bin/user/ambientweatherapi.py
@@ -245,21 +245,22 @@ class AmbientWeatherAPI(weewx.drivers.AbstractDevice):
                         lastRain = float(intervalRain.read())
                     except ValueError:
                         logging.debug('String value found instead. Assuming zero interval rain and recording current value')
-                        lastRain = self.get_float(dailyrainin)
+                        lastRain = self.get_float(data['dailyrainin'])
                     intervalRain.close()
                     logging.debug('Previous daily rain: ', lastRain)
                 else:
                     logging.debug('No previous value found for rain, assuming interval of 0 and recording daily value')
-                    lastRain = self.get_float(dailyrainin)
-                logging.debug('Reported daily rain: ', self.get_float(dailyrainin))
-                if lastRain > self.get_float(dailyrainin):
-                    correctedRain = self.get_float(dailyrainin)
+                    lastRain = self.get_float(data['dailyrainin'])
+                logging.debug('Reported daily rain: %s' % str(data['dailyrainin']))
+                if lastRain > self.get_float(data['dailyrainin']):
+                    correctedRain = self.get_float(data['dailyrainin'])
                     logging.debug('Recorded rain is more than reported rain; using reported rain')
                 else:
-                    correctedRain = self.get_float(dailyrainin) - lastRain
-                logging.debug('Calculated interval rain: ', correctedRain)
+                    correctedRain = self.get_float(data['dailyrainin']) - lastRain
+
+                logging.debug('Calculated interval rain: %s' % correctedRain)
                 intervalRain = open('rain.txt', 'w')
-                intervalRain.write(str(dailyrainin))
+                intervalRain.write(str(data['dailyrainin']))
                 intervalRain.close()
                     
                 # Create the initial packet dict
@@ -280,7 +281,7 @@ class AmbientWeatherAPI(weewx.drivers.AbstractDevice):
                         else:
                             _packet[key] = self.get_float(data[value])
                     else:
-                        logging.info("Dropping Ambient value: '%s' from Weewx packet." % (value))
+                        logging.debug("Dropping Ambient value: '%s' from Weewx packet." % (value))
 
                 if logging.DEBUG >= logging.root.level:
                     self.print_dict(_packet)

--- a/bin/user/ambientweatherapi.py
+++ b/bin/user/ambientweatherapi.py
@@ -223,7 +223,7 @@ class AmbientWeatherAPI(weewx.drivers.AbstractDevice):
 				# Read previous daily rain total, and write most recent daily rain back to file
 				if path.exists('rain.txt') == True:
 					logging.debug('Opening file')
-					intervalRain = open('/Users/Shared/weewx/rain.txt', 'r')
+					intervalRain = open('rain.txt', 'r')
 					try:
 						lastRain = float(intervalRain.read())
 					except ValueError:
@@ -241,7 +241,7 @@ class AmbientWeatherAPI(weewx.drivers.AbstractDevice):
 				else:
 					correctedRain = self.get_float(dailyrainin) - lastRain
 				logging.debug('Calculated interval rain: ', correctedRain)
-				intervalRain = open('/Users/Shared/weewx/rain.txt', 'w')
+				intervalRain = open('rain.txt', 'w')
 				intervalRain.write(str(dailyrainin))
 				intervalRain.close()
 

--- a/bin/user/ambientweatherapi.py
+++ b/bin/user/ambientweatherapi.py
@@ -18,6 +18,10 @@ import weewx.wxformulas
 import os.path
 from os import path
 
+this_file = os.path.join(os.getcwd(), __file__)
+this_dir = os.path.abspath(os.path.dirname(this_file))
+os.chdir(this_dir)
+
 DRIVER_NAME = 'ambientweatherapi'
 DRIVER_VERSION = '0.1'
 

--- a/bin/user/ambientweatherapi.py
+++ b/bin/user/ambientweatherapi.py
@@ -222,25 +222,25 @@ class AmbientWeatherAPI(weewx.drivers.AbstractDevice):
 
 				# Read previous daily rain total, and write most recent daily rain back to file
 				if path.exists('rain.txt') == True:
-					print('Opening file')
+					logging.debug('Opening file')
 					intervalRain = open('/Users/Shared/weewx/rain.txt', 'r')
 					try:
 						lastRain = float(intervalRain.read())
 					except ValueError:
-						print('String value found instead. Assuming zero interval rain and recording current value')
+						logging.debug('String value found instead. Assuming zero interval rain and recording current value')
 						lastRain = self.get_float(dailyrainin)
 					intervalRain.close()
-					print('Previous daily rain: ', lastRain)
+					logging.debug('Previous daily rain: ', lastRain)
 				else:
-					print('No previous value found for rain, assuming interval of 0 and recording daily value')
+					logging.debug('No previous value found for rain, assuming interval of 0 and recording daily value')
 					lastRain = self.get_float(dailyrainin)
-				print('Reported daily rain: ', self.get_float(dailyrainin))
+				logging.debug('Reported daily rain: ', self.get_float(dailyrainin))
 				if lastRain > self.get_float(dailyrainin):
 					correctedRain = self.get_float(dailyrainin)
-					print('Recorded rain is more than reported rain; using reported rain')
+					logging.debug('Recorded rain is more than reported rain; using reported rain')
 				else:
 					correctedRain = self.get_float(dailyrainin) - lastRain
-				print('Calculated interval rain: ', correctedRain)
+				logging.debug('Calculated interval rain: ', correctedRain)
 				intervalRain = open('/Users/Shared/weewx/rain.txt', 'w')
 				intervalRain.write(str(dailyrainin))
 				intervalRain.close()

--- a/bin/user/ambientweatherapi.py
+++ b/bin/user/ambientweatherapi.py
@@ -236,15 +236,15 @@ class AmbientWeatherAPI(weewx.drivers.AbstractDevice):
                 if error_occured:
                     error_occured = False
                     raise Exception('Previous error occured, skipping packet build.')
-                    
+
                 # Read previous daily rain total, and write most recent daily rain back to file
-                if path.exists('rain.txt') == True:
+                if path.exists('rain.txt'):
                     logging.debug('Opening file')
                     intervalRain = open('rain.txt', 'r')
                     try:
                         lastRain = float(intervalRain.read())
                     except ValueError:
-                        logging.debug('String value found instead. Assuming zero interval rain and recording current value')
+                        logging.debug('String value found. Assuming zero interval rain and recording current value')
                         lastRain = self.get_float(data['dailyrainin'])
                     intervalRain.close()
                     logging.debug('Previous daily rain: ', lastRain)
@@ -262,7 +262,7 @@ class AmbientWeatherAPI(weewx.drivers.AbstractDevice):
                 intervalRain = open('rain.txt', 'w')
                 intervalRain.write(str(data['dailyrainin']))
                 intervalRain.close()
-                    
+
                 # Create the initial packet dict
                 _packet = {
                     'dateTime': current_observation,
@@ -298,6 +298,7 @@ class AmbientWeatherAPI(weewx.drivers.AbstractDevice):
             logging.debug("Going to sleep")
             time.sleep(self.loop_interval)
             logging.debug("Mom, I'm up!")
+
 
 if __name__ == "__main__":
     driver = AmbientWeatherAPI()


### PR DESCRIPTION
Updated code with fix for rain rate (driver now calculates and reports how much rain has fallen since the previous loop, not since the beginning of the day), and for barometer readings (updated relative/absolute pressure to match weewx specifications). Also commented out 'yearlyrainin' and 'pm25' fields to stop errors, since they are not present in the API data for my station. 