### PR TITLE
Add ability to specify station MAC

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,3 @@ The following table outlines the `weewx.conf` station variables.
 | station_mac | Specify a specific station MAC address to return data.  If blank or unspecified, then the first station in the list is returned. |
 | hardware | String to identify the hardware used |
 | driver | Don't change this value |
-
-## TODO
-1) Automate the install using `wee_extension`

--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@ This driver only works with Weewx 4.0+ and Python3.
 sudo -H pip3 install -r requirements.txt
 ````
 
-2) Copy `bin/user/ambientweatherapi.py` to the `bin/user` directory.  The directory location depends on your install type.  See [here](https://weewx.com/docs/usersguide.htm#Where_to_find_things) for more informaiton on how to find your `user` directory.
+2) Install the extension
+````bash
+weectl extension install https://github.com/themoosman/weewx-ambientweatherapi-json/archive/master.zip --yes
+````
+
 3) Modify `weewx.conf` using the snippets in this repo's `weeex.conf`
 4) Restart `weewx`
 
@@ -31,6 +35,7 @@ The following table outlines the `weewx.conf` station variables.
 | api_app_key | API Application Key from your ambientweather.net [website](https://ambientweather.docs.apiary.io/#) |
 | api_key | API Key from your ambientweather.net [website](https://ambientweather.docs.apiary.io/#) |
 | use_meteobridge | Set to `True` if using Meteobridge, `False` is the default or leave commented out |
+| station_mac | Specify a specific station MAC address to return data.  If blank or unspecified, then the first station in the list is returned. |
 | hardware | String to identify the hardware used |
 | driver | Don't change this value |
 

--- a/bin/user/ambientweatherapi.py
+++ b/bin/user/ambientweatherapi.py
@@ -315,15 +315,12 @@ class AmbientWeatherAPI(weewx.drivers.AbstractDevice):
 
                 # get the last report dict
                 data = devices[0].last_data
-                logging.info(devices[0])
                 if self.use_station_mac:
                     logging.debug('Looking for specific Station MAC')
-                    length = len(devices)
-                    for i in range(length):
-                        device = devices[i]
+                    for device in devices:
                         if device.mac_address == self.station_mac:
                             logging.info("Found station mac: %s" % self.station_mac)
-                            data = devices[i].last_data
+                            data = device.last_data
                             break
                         else:
                             logging.debug('No specific MAC specified, using first station.')

--- a/bin/user/ambientweatherapi.py
+++ b/bin/user/ambientweatherapi.py
@@ -106,10 +106,9 @@ class AmbientWeatherAPI(weewx.drivers.AbstractDevice):
 
     def print_dict(self, data_dict):
         """Prints a dict."""
-        if logging.INFO >= logging.root.level:
-            logging.debug("calling: print_dict")
-            for key in data_dict:
-                logging.debug(key + " = " + str(data_dict[key]))
+        logging.info("calling: print_dict")
+        for key in data_dict:
+            logging.into(key + " = " + str(data_dict[key]))
 
     def get_value(self, data_dict, key):
         """Gets the value from a dict, returns None if the key does not exist."""

--- a/bin/user/ambientweatherapi.py
+++ b/bin/user/ambientweatherapi.py
@@ -19,7 +19,7 @@ import os.path
 from os import path
 
 DRIVER_NAME = 'ambientweatherapi'
-DRIVER_VERSION = '0.0.10'
+DRIVER_VERSION = '0.0.11'
 
 
 def loader(config_dict, engine):

--- a/bin/user/ambientweatherapi.py
+++ b/bin/user/ambientweatherapi.py
@@ -316,7 +316,6 @@ class AmbientWeatherAPI(weewx.drivers.AbstractDevice):
                 # get the last report dict
                 data = devices[0].last_data
                 logging.info(devices[0])
-                self.print_dict(devices[0])
                 if self.use_station_mac:
                     logging.debug('Looking for specific Station MAC')
                     length = len(devices)

--- a/bin/user/ambientweatherapi.py
+++ b/bin/user/ambientweatherapi.py
@@ -319,10 +319,10 @@ class AmbientWeatherAPI(weewx.drivers.AbstractDevice):
                 self.print_dict( devices[0])
                 if self.use_station_mac:
                     logging.debug('Looking for specific Station MAC')
-                    for device in devices:
+                    for i, device in enumerate(devices):
                         if device.mac_address == self.station_mac:
                             logging.info("Found station mac: %s" % self.station_mac)
-                            data = device.last_data
+                            data = devices[i].last_data
                             break
                         else:
                             logging.debug('No specific MAC specified, using first station.')

--- a/bin/user/ambientweatherapi.py
+++ b/bin/user/ambientweatherapi.py
@@ -50,6 +50,12 @@ class AmbientWeatherAPI(weewx.drivers.AbstractDevice):
         self.max_humidity = float(stn_dict.get('max_humidity', 38))
         self.use_meteobridge = bool(stn_dict.get('use_meteobridge', False))
         logging.info('use_meteobridge: %s' % str(self.use_meteobridge))
+        self.station_mac = stn_dict.get('station_mac', '')
+        self.use_station_mac = False
+        if not self.station_mac:
+            logging.info("No Station MAC specified.")
+        else:
+            self.use_station_mac = True
         self.rainfilepath = os.path.join(tempfile.gettempdir(), rainfile)
         logging.info('Starting: %s, version: %s' % (DRIVER_NAME, DRIVER_VERSION))
         logging.debug("Exiting init()")

--- a/bin/user/ambientweatherapi.py
+++ b/bin/user/ambientweatherapi.py
@@ -97,18 +97,12 @@ class AmbientWeatherAPI(weewx.drivers.AbstractDevice):
         utc_epoch_sec = epoch_ms / 1000
         return utc_epoch_sec
 
-    def print_dict1(self, data_dict):
+    def print_dict(self, data_dict):
         """Prints a dict."""
         if logging.DEBUG >= logging.root.level:
             logging.debug("calling: print_dict")
             for key in data_dict:
                 logging.debug(key + " = " + str(data_dict[key]))
-
-    def print_dict(self, data_dict):
-        """Prints a dict."""
-        logging.info("calling: print_dict")
-        for key in data_dict:
-            logging.info(key + " = " + str(data_dict[key]))
 
     def get_value(self, data_dict, key):
         """Gets the value from a dict, returns None if the key does not exist."""

--- a/bin/user/ambientweatherapi.py
+++ b/bin/user/ambientweatherapi.py
@@ -316,10 +316,12 @@ class AmbientWeatherAPI(weewx.drivers.AbstractDevice):
                 # get the last report dict
                 data = devices[0].last_data
                 logging.info(devices[0])
-                self.print_dict( devices[0])
+                self.print_dict(devices[0])
                 if self.use_station_mac:
                     logging.debug('Looking for specific Station MAC')
-                    for i, device in enumerate(devices):
+                    length = len(devices)
+                    for i in range(length):
+                        device = devices[i]
                         if device.mac_address == self.station_mac:
                             logging.info("Found station mac: %s" % self.station_mac)
                             data = devices[i].last_data

--- a/bin/user/ambientweatherapi.py
+++ b/bin/user/ambientweatherapi.py
@@ -320,7 +320,7 @@ class AmbientWeatherAPI(weewx.drivers.AbstractDevice):
                 if self.use_station_mac:
                     logging.debug('Looking for specific Station MAC')
                     for device in devices:
-                        if device.macAddress == self.station_mac:
+                        if device.mac_address == self.station_mac:
                             logging.info("Found station mac: %s" % self.station_mac)
                             data = device.last_data
                             break

--- a/bin/user/ambientweatherapi.py
+++ b/bin/user/ambientweatherapi.py
@@ -108,7 +108,7 @@ class AmbientWeatherAPI(weewx.drivers.AbstractDevice):
         """Prints a dict."""
         logging.info("calling: print_dict")
         for key in data_dict:
-            logging.into(key + " = " + str(data_dict[key]))
+            logging.info(key + " = " + str(data_dict[key]))
 
     def get_value(self, data_dict, key):
         """Gets the value from a dict, returns None if the key does not exist."""

--- a/bin/user/ambientweatherapi.py
+++ b/bin/user/ambientweatherapi.py
@@ -300,7 +300,6 @@ class AmbientWeatherAPI(weewx.drivers.AbstractDevice):
                 # get the first device
                 devices = weather.get_devices()
                 logging.debug("Got weather devices")
-
                 if not devices:
                     logging.error('AmbientAPI get_devices() returned empty dict')
                     raise Exception('AmbientAPI get_devices() returned empty dict')
@@ -309,6 +308,15 @@ class AmbientWeatherAPI(weewx.drivers.AbstractDevice):
 
                 # get the last report dict
                 data = devices[0].last_data
+                if self.use_station_mac:
+                    logging.debug('Looking for specific Station MAC')
+                    for device in devices:
+                        if device.macAddress == self.station_mac:
+                            logging.info("Found station mac: %s", self.station_mac)
+                            data = device.last_data
+                            break
+                        else:
+                            logging.debug('No specific MAC specified, using first station.')
                 # info = devices[0].info
                 logging.debug("Got last report")
 

--- a/bin/user/ambientweatherapi.py
+++ b/bin/user/ambientweatherapi.py
@@ -315,6 +315,7 @@ class AmbientWeatherAPI(weewx.drivers.AbstractDevice):
 
                 # get the last report dict
                 data = devices[0].last_data
+                logging.info(devices[0])
                 self.print_dict( devices[0])
                 if self.use_station_mac:
                     logging.debug('Looking for specific Station MAC')

--- a/bin/user/ambientweatherapi.py
+++ b/bin/user/ambientweatherapi.py
@@ -315,7 +315,7 @@ class AmbientWeatherAPI(weewx.drivers.AbstractDevice):
 
                 # get the last report dict
                 data = devices[0].last_data
-                self.print_dict(data)
+                self.print_dict( devices[0])
                 if self.use_station_mac:
                     logging.debug('Looking for specific Station MAC')
                     for device in devices:

--- a/bin/user/ambientweatherapi.py
+++ b/bin/user/ambientweatherapi.py
@@ -97,9 +97,16 @@ class AmbientWeatherAPI(weewx.drivers.AbstractDevice):
         utc_epoch_sec = epoch_ms / 1000
         return utc_epoch_sec
 
-    def print_dict(self, data_dict):
+    def print_dict1(self, data_dict):
         """Prints a dict."""
         if logging.DEBUG >= logging.root.level:
+            logging.debug("calling: print_dict")
+            for key in data_dict:
+                logging.debug(key + " = " + str(data_dict[key]))
+
+    def print_dict(self, data_dict):
+        """Prints a dict."""
+        if logging.INFO >= logging.root.level:
             logging.debug("calling: print_dict")
             for key in data_dict:
                 logging.debug(key + " = " + str(data_dict[key]))

--- a/bin/user/ambientweatherapi.py
+++ b/bin/user/ambientweatherapi.py
@@ -53,7 +53,7 @@ class AmbientWeatherAPI(weewx.drivers.AbstractDevice):
         self.station_mac = stn_dict.get('station_mac', '')
         self.use_station_mac = False
         if not self.station_mac:
-            logging.info("No Station MAC specified.")
+            logging.info("No Station MAC specified.  The first station will be returned.")
         else:
             logging.info("Using Station MAC: %s" % self.station_mac)
             self.use_station_mac = True
@@ -307,17 +307,18 @@ class AmbientWeatherAPI(weewx.drivers.AbstractDevice):
                 else:
                     logging.debug('Weather get_devices() payload not empty')
 
-                # get the last report dict
+                # get the last report dict for the first station
                 data = devices[0].last_data
+                # check to see if the user wants a specific MAC
                 if self.use_station_mac:
-                    logging.debug('Looking for specific Station MAC')
+                    logging.debug('Searching for specific Station MAC')
                     for device in devices:
                         if device.mac_address == self.station_mac:
                             logging.info("Found station mac: %s" % self.station_mac)
                             data = device.last_data
                             break
                         else:
-                            logging.debug('No specific MAC specified, using first station.')
+                            logging.debug('Specified MAC not found, using first station.')
                 # info = devices[0].info
                 logging.debug("Got last report")
 

--- a/bin/user/ambientweatherapi.py
+++ b/bin/user/ambientweatherapi.py
@@ -55,6 +55,7 @@ class AmbientWeatherAPI(weewx.drivers.AbstractDevice):
         if not self.station_mac:
             logging.info("No Station MAC specified.")
         else:
+            logging.info("Using Station MAC: %s" % self.station_mac)
             self.use_station_mac = True
         self.rainfilepath = os.path.join(tempfile.gettempdir(), rainfile)
         logging.info('Starting: %s, version: %s' % (DRIVER_NAME, DRIVER_VERSION))
@@ -308,11 +309,12 @@ class AmbientWeatherAPI(weewx.drivers.AbstractDevice):
 
                 # get the last report dict
                 data = devices[0].last_data
+                self.print_dict(data)
                 if self.use_station_mac:
                     logging.debug('Looking for specific Station MAC')
                     for device in devices:
                         if device.macAddress == self.station_mac:
-                            logging.info("Found station mac: %s", self.station_mac)
+                            logging.info("Found station mac: %s" % self.station_mac)
                             data = device.last_data
                             break
                         else:

--- a/weewx.conf
+++ b/weewx.conf
@@ -25,6 +25,9 @@
     #Ambient Weather API Key
     api_key = ''
 
+    #MAC Address of station to reutrn data (default is the first station in the list.)
+    #station_mac = ''
+
     #Ambient Weather Use Meteobridge (default if False)
     #use_meteobridge = ''
 


### PR DESCRIPTION
Currently, this driver would only return to the first station in the station list.  For users with multiple stations, this may not be an idea.  This PR allows the user to specify the station MAC to use and return data.